### PR TITLE
fix: check if `has_parser` exists

### DIFF
--- a/ftplugin/help.lua
+++ b/ftplugin/help.lua
@@ -4,7 +4,7 @@ local cursor_pos = {};
 local ts_available, treesitter_parsers = pcall(require, "nvim-treesitter.parsers");
 
 local parser_installed = function (parser_name)
-	return (ts_available and treesitter_parsers.has_parser(parser_name)) or vim.treesitter.query.get(parser_name, "highlights");
+	return (ts_available and treesitter_parsers.has_parser and treesitter_parsers.has_parser(parser_name)) or vim.treesitter.query.get(parser_name, "highlights");
 end
 
 if vim.fn.has("nvim-0.10") == 0 then


### PR DESCRIPTION
Try to use this plugin on nvim-treesitter's `main` branch:
```
E5113: Error while calling lua chunk: ...n/.local/share/nvim/lazy/helpview.nvim/ftplugin/help.lua:7: attempt to call field 'has_parser' (a nil value)
stack traceback:
        ...n/.local/share/nvim/lazy/helpview.nvim/ftplugin/help.lua:7: in function 'parser_installed'
        ...n/.local/share/nvim/lazy/helpview.nvim/ftplugin/help.lua:13: in main chunk
```
